### PR TITLE
75 msp files with crlf end of line characters dont properly load into the biological standards

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydrive2==1.14.0
 slack_sdk==3.18.1
 sqlalchemy==1.4.32
 watchdog==2.1.9
+flask==2.2.4

--- a/src/ms_autoqc/AutoQCProcessing.py
+++ b/src/ms_autoqc/AutoQCProcessing.py
@@ -263,7 +263,7 @@ def run_msconvert(path, filename, extension, output_folder):
         return None
 
     # Run MSConvert in a subprocess
-    command = msconvert_exe + output_folder + filename + "." + extension + " -o " + output_folder
+    command = msconvert_exe + '"' + output_folder + filename + "." + extension + '"' + " -o " + '"' + output_folder + '"'
     process = psutil.Popen(command)
     pid = process.pid
 
@@ -315,9 +315,9 @@ def run_msdial_processing(filename, msdial_path, parameter_file, input_folder, o
     os.chdir(msdial_path)
 
     # Run MS-DIAL in a subprocess
-    command = "MsdialConsoleApp.exe lcmsdda -i " + input_folder \
-              + " -o " + output_folder \
-              + " -m " + parameter_file + " -p"
+    command = "MsdialConsoleApp.exe lcmsdda -i " + '"' + input_folder + '"' \
+            + " -o " + '"' + output_folder + '"' \
+            + " -m " + '"' + parameter_file + '"' + " -p"
     process = psutil.Popen(command)
     pid = process.pid
 

--- a/src/ms_autoqc/DatabaseFunctions.py
+++ b/src/ms_autoqc/DatabaseFunctions.py
@@ -1574,7 +1574,6 @@ def add_msp_to_database(msp_file, chromatography, polarity, bio_standard=None):
     Returns:
         None
     """
-
     # Connect to database
     db_metadata, connection = connect_to_database("Settings")
 
@@ -1595,13 +1594,12 @@ def add_msp_to_database(msp_file, chromatography, polarity, bio_standard=None):
 
     msp_file_path = os.path.join(methods_directory, filename)
 
-    with open(msp_file_path, "w") as file:
+    with open(msp_file_path, "w", newline='') as file:
         msp_file.seek(0)
         shutil.copyfileobj(msp_file, file)
 
     # Read MSP file
     with open(msp_file_path, "r") as msp:
-
         list_of_features = []
 
         # Split MSP into list of compounds


### PR DESCRIPTION
Crude fix for spaces in job ID and file system path from derailing commands to msconvert and msdial, should probably be using pathlib or something similar.
Fixed .msp files with CRLF line endings (common on windows) from getting mangled on import.